### PR TITLE
Удаляются теги из всех записей

### DIFF
--- a/system/controllers/tags/model.php
+++ b/system/controllers/tags/model.php
@@ -220,6 +220,8 @@ class modelTags extends cmsModel{
 		
 		if (!$tags_ids) { return; }
 		
+	$this->filterTarget($controller, $subject, $id);
+		
         $this->filterIn('tag_id', $tags_ids);
 
         $this->deleteFiltered('tags_bind');


### PR DESCRIPTION
Я как-то говорил **r2** об этой "баге", но решил сюда тоже добавить...
При удалении одной из записей с тегом (или несколькими тегами), который содержится еще в других записях, этот тег полностью удаляется из таблицы **{#}_tags**, и соответственно из всех остальных записей! Дополнительная фильтрация решает данную проблему.